### PR TITLE
Prevent Qute “Key 'query' not found” errors on single-item pages

### DIFF
--- a/vintage-store/src/main/java/org/agoncal/quarkus/panache/page/ArtistPage.java
+++ b/vintage-store/src/main/java/org/agoncal/quarkus/panache/page/ArtistPage.java
@@ -34,9 +34,18 @@ public class ArtistPage {
 
   @GET
   @Path("{id}")
-  public TemplateInstance showArtistById(@PathParam("id") Long id) {
-    return Templates.artist(repository.findById(id));
+  public TemplateInstance showArtistById(@PathParam("id") Long id,
+                                        @QueryParam("query") @DefaultValue("") String query,
+                                        @QueryParam("sort") @DefaultValue("id") String sort,
+                                        @QueryParam("page") @DefaultValue("0") Integer pageIndex,
+                                        @QueryParam("size") @DefaultValue("1000") Integer pageSize) {
+      return Templates.artist(repository.findById(id))
+        .data("query", query)
+        .data("sort", sort)
+        .data("pageIndex", pageIndex)
+        .data("pageSize", pageSize);
   }
+
 
   @GET
   public TemplateInstance showAllArtists(@QueryParam("query") String query, @QueryParam("sort") @DefaultValue("id") String sort, @QueryParam("page") @DefaultValue("0") Integer pageIndex, @QueryParam("size") @DefaultValue("1000") Integer pageSize) {

--- a/vintage-store/src/main/java/org/agoncal/quarkus/panache/page/CustomerPage.java
+++ b/vintage-store/src/main/java/org/agoncal/quarkus/panache/page/CustomerPage.java
@@ -34,8 +34,16 @@ public class CustomerPage {
 
   @GET
   @Path("{id}")
-  public TemplateInstance showCustomerById(@PathParam("id") Long id) {
-    return Templates.customer(repository.findById(id));
+  public TemplateInstance showCustomerById(@PathParam("id") Long id,
+                                       @QueryParam("query") @DefaultValue("") String query,
+                                       @QueryParam("sort") @DefaultValue("id") String sort,
+                                       @QueryParam("page") @DefaultValue("0") Integer pageIndex,
+                                       @QueryParam("size") @DefaultValue("1000") Integer pageSize) {
+    return Templates.customer(repository.findById(id))
+                    .data("query", query)
+                    .data("sort", sort)
+                    .data("pageIndex", pageIndex)
+                    .data("pageSize", pageSize);
   }
 
   @GET

--- a/vintage-store/src/main/java/org/agoncal/quarkus/panache/page/ItemPage.java
+++ b/vintage-store/src/main/java/org/agoncal/quarkus/panache/page/ItemPage.java
@@ -34,8 +34,16 @@ public class ItemPage {
 
   @GET
   @Path("/books/{id}")
-  public TemplateInstance showBookById(@PathParam("id") Long id) {
-    return Templates.book(Book.findById(id));
+  public TemplateInstance showBookById(@PathParam("id") Long id,
+                                       @QueryParam("query") @DefaultValue("") String query,
+                                       @QueryParam("sort") @DefaultValue("id") String sort,
+                                       @QueryParam("page") @DefaultValue("0") Integer pageIndex,
+                                       @QueryParam("size") @DefaultValue("1000") Integer pageSize) {
+    return Templates.book(Book.findById(id))
+                    .data("query", query)
+                    .data("sort", sort)
+                    .data("pageIndex", pageIndex)
+                    .data("pageSize", pageSize);
   }
 
   @GET
@@ -50,8 +58,16 @@ public class ItemPage {
 
   @GET
   @Path("/cds/{id}")
-  public TemplateInstance showCDById(@PathParam("id") Long id) {
-    return Templates.cd(CD.findById(id));
+  public TemplateInstance showCDById(@PathParam("id") Long id,
+                                       @QueryParam("query") @DefaultValue("") String query,
+                                       @QueryParam("sort") @DefaultValue("id") String sort,
+                                       @QueryParam("page") @DefaultValue("0") Integer pageIndex,
+                                       @QueryParam("size") @DefaultValue("1000") Integer pageSize) {
+    return Templates.cd(CD.findById(id))
+                    .data("query", query)
+                    .data("sort", sort)
+                    .data("pageIndex", pageIndex)
+                    .data("pageSize", pageSize);
   }
 
   @GET

--- a/vintage-store/src/main/java/org/agoncal/quarkus/panache/page/PublisherPage.java
+++ b/vintage-store/src/main/java/org/agoncal/quarkus/panache/page/PublisherPage.java
@@ -29,16 +29,25 @@ public class PublisherPage {
 
   @GET
   @Path("{id}")
-  public TemplateInstance showPublisherById(@PathParam("id") Long id) {
-    return Templates.publisher(Publisher.findById(id));
+  public TemplateInstance showPublisherById(@PathParam("id") Long id,
+                                       @QueryParam("query") @DefaultValue("") String query,
+                                       @QueryParam("sort") @DefaultValue("id") String sort,
+                                       @QueryParam("page") @DefaultValue("0") Integer pageIndex,
+                                       @QueryParam("size") @DefaultValue("1000") Integer pageSize) {
+    return Templates.publisher(Publisher.findById(id))
+                    .data("query", query)
+                    .data("sort", sort)
+                    .data("pageIndex", pageIndex)
+                    .data("pageSize", pageSize);
   }
 
   @GET
   public TemplateInstance showAllPublishers(@QueryParam("query") String query, @QueryParam("sort") @DefaultValue("id") String sort, @QueryParam("page") @DefaultValue("0") Integer pageIndex, @QueryParam("size") @DefaultValue("1000") Integer pageSize) {
-    return Templates.publishers(Publisher.find(query, Sort.by(sort)).page(pageIndex, pageSize).list())
+    return Templates.publishers(Publisher.find(query, Sort.by(sort))
+        .page(pageIndex, pageSize).list())
       .data("query", query)
       .data("sort", sort)
-      .data("page", pageIndex)
-      .data("size", pageSize);
+      .data("pageIndex", pageIndex)
+      .data("pageSize", pageSize);
   }
 }


### PR DESCRIPTION
Pass query, sort, pageIndex, and pageSize data to the artist template so that
base.html can render without throwing "Key 'query' not found" errors.